### PR TITLE
feat(api): adiciona rota POST para criar álbum e atualiza README com justificativa do Github Flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # API de Álbuns Musicais Brasileiros
 
 ## Descrição
-API REST simples para listar álbuns musicais brasileiros.
+API REST simples para listar e adicionar álbuns musicais brasileiros.
 
 ## Pré-requisitos
 - Python 3.8+
@@ -25,3 +25,46 @@ API REST simples para listar álbuns musicais brasileiros.
 - python app.py
 
 Acesse: [http://localhost:5000/api/albuns](http://localhost:5000/api/albuns)
+
+---
+
+## Workflow Utilizado
+
+Este projeto utiliza o **Github Flow** como estratégia de controle de versão.  
+O Github Flow é um fluxo de trabalho simples e direto, recomendado para projetos com uma única versão em produção, como APIs simples, sites e blogs.  
+Neste fluxo, todo desenvolvimento parte da branch principal (`main`), e cada nova funcionalidade ou correção é feita em uma branch separada, sendo mesclada à `main` após revisão. Isso facilita deploys frequentes e mantém o código de produção sempre atualizado.
+
+**Por que escolhi o Github Flow?**
+- O projeto é simples, com uma única versão em produção.
+- Permite adicionar e revisar novas funcionalidades de forma rápida.
+- Facilita o controle e a colaboração, mesmo em equipes pequenas.
+
+---
+
+## Rotas da API
+
+### Listar álbuns (GET)
+- **Endpoint:** `/api/albuns`
+- **Método:** GET
+- **Descrição:** Retorna a lista de álbuns musicais brasileiros.
+- **Exemplo de uso:**  
+  Acesse [http://localhost:5000/api/albuns](http://localhost:5000/api/albuns) pelo navegador ou pelo Postman.
+
+### Adicionar álbum (POST)
+- **Endpoint:** `/api/albuns`
+- **Método:** POST
+- **Descrição:** Adiciona um novo álbum à lista.
+- **Exemplo de uso no Postman:**
+  1. Selecione o método **POST**.
+  2. Use a URL: `http://localhost:5000/api/albuns`
+  3. Na aba **Body**, escolha **raw** e selecione **JSON**.
+  4. Insira um JSON como, por exemplo:
+     ```
+     {
+       "nome": "Tropicália",
+       "artista": "Caetano Veloso",
+       "ano": 1968
+     }
+     ```
+  5. Clique em **Send**.  
+     A resposta será o álbum criado, com um novo `id`.

--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask, jsonify
+from flask import Flask, jsonify, request
 
 app = Flask(__name__)
 
@@ -7,9 +7,17 @@ albuns = [
     {"id": 2, "nome": "Acabou Chorare", "artista": "Novos Baianos", "ano": 1972}
 ]
 
-@app.route('/api/albuns', methods=['GET'])
-def get_albuns():
-    return jsonify(albuns)
-
-if __name__ == '__main__':
-    app.run(debug=True)
+@app.route('/api/albuns', methods=['GET', 'POST'])
+def albuns_handler():
+    if request.method == 'GET':
+        return jsonify(albuns)
+    elif request.method == 'POST':
+        data = request.get_json()
+        novo_album = {
+            "id": len(albuns) + 1,
+            "nome": data.get("nome"),
+            "artista": data.get("artista"),
+            "ano": data.get("ano")
+        }
+        albuns.append(novo_album)
+        return jsonify(novo_album), 201


### PR DESCRIPTION
- Implementa a rota POST /api/albuns, permitindo a adição de novos álbuns musicais brasileiros via requisições JSON.
- Atualiza o README.md com instruções detalhadas de uso da nova rota, incluindo exemplos de teste no Postman.
- Acrescenta uma seção explicando a escolha do workflow Github Flow, destacando que é o mais indicado para projetos simples e com apenas uma versão em produção, conforme orientado na aula.

Esta PR segue o Github Flow, criando a feature em uma branch separada a partir da main e propondo o merge após revisão, garantindo organização e facilidade de colaboração no projeto.
